### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,11 @@ body {
 .navbar-dark .navbar-nav .nav-link-disabled{
   color: rgb(85, 73, 73);
 }
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
   <body>    
     <header>
       <%= render "layouts/header" %>
+      <%= render "layouts/flash" %>
     </header>
     <main>
       <#% max_width メソッドは application_helper.rb に記載 %>


### PR DESCRIPTION
close #12 

## 実装内容
- フラッシュの表示機能実装
  - ナビバー同様，横幅一杯の表示とする
  - ログイン・ログアウト時にフラッシュ表示
  - フラッシュの背景色を設定

## 参考資料

- [やんばるCODE教材（メッセージ投稿アプリ その3）](https://www.yanbaru-code.com/texts/271)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
