### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem 'devise-i18n'
 
 # Bootstrap
 gem 'devise-bootstrap-views', '~> 1.0'
+# Markdown
+gem 'redcarpet'
+# シンタックスハイライト
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -254,6 +255,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
@@ -265,6 +267,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -5,4 +5,8 @@ class TextsController < ApplicationController
     # ()にマッチするレコードを全て取得する
     @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
   end
+
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,48 @@
 module ApplicationHelper
+  require 'redcarpet'
+  require 'coderay'
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0] if language.present?
+
+      lang = case language.to_s
+             when 'rb'
+               'ruby'
+             when 'yml'
+               'yaml'
+             when 'css'
+               'css'
+             when 'html'
+               'html'
+             when ''
+               # 空欄のままだと「Invalid id given:」エラー
+               'md'
+             else
+               language
+             end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(filter_html: true, hard_wrap: true)
+
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
+  end
+  
   def max_width
     devise_controller? ? 'mw-md' : 'mw-xl'
   end
@@ -7,4 +51,3 @@ module ApplicationHelper
     "disabled" unless user_signed_in?
   end
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,47 +1,4 @@
 module ApplicationHelper
-  require 'redcarpet'
-  require 'coderay'
-  class HTMLwithCoderay < Redcarpet::Render::HTML
-    def block_code(code, language)
-      language = language.split(':')[0] if language.present?
-
-      lang = case language.to_s
-             when 'rb'
-               'ruby'
-             when 'yml'
-               'yaml'
-             when 'css'
-               'css'
-             when 'html'
-               'html'
-             when ''
-               # 空欄のままだと「Invalid id given:」エラー
-               'md'
-             else
-               language
-             end
-
-      CodeRay.scan(code, lang).div
-    end
-  end
-
-  def markdown(text)
-    html_render = HTMLwithCoderay.new(filter_html: true, hard_wrap: true)
-
-    options = {
-      autolink: true,
-      space_after_headers: true,
-      no_intra_emphasis: true,
-      fenced_code_blocks: true,
-      tables: true,
-      hard_wrap: true,
-      xhtml: true,
-      lax_html_blocks: true,
-      strikethrough: true
-    }
-    markdown = Redcarpet::Markdown.new(html_render, options)
-    markdown.render(text).html_safe
-  end
   
   def max_width
     devise_controller? ? 'mw-md' : 'mw-xl'

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,45 @@
+module MarkdownHelper
+  require 'redcarpet'
+  require 'coderay'
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0] if language.present?
+
+      lang = case language.to_s
+             when 'rb'
+               'ruby'
+             when 'yml'
+               'yaml'
+             when 'css'
+               'css'
+             when 'html'
+               'html'
+             when ''
+               # 空欄のままだと「Invalid id given:」エラー
+               'md'
+             else
+               language
+             end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(filter_html: true, hard_wrap: true)
+
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,6 +1,4 @@
 module MarkdownHelper
-  require 'redcarpet'
-  require 'coderay'
   class HTMLwithCoderay < Redcarpet::Render::HTML
     def block_code(code, language)
       language = language.split(':')[0] if language.present?

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,13 +5,15 @@
       <% @texts.each do |text| %>
         <div class="col-12 col-md-6 col-lg-4">
           <div class="card">
+          <%= link_to text_path(text.id), target: ":_blank" do%>
             <img class="card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="カード画像">
-              <div class="card-body">
-                <%# ボタンは別タスク
-                <a href="#" class="btn btn-primary">Go somewhere</a> %>
-                <p class="card-title"><%= text.title %></p>
-                <p class="card-text">【<%= text.genre %>】</p>
-              </div>
+          <% end %>
+          <div class="card-body">
+            <%# ボタンは別タスク
+            <a href="#" class="btn btn-primary">Go somewhere</a> %>
+            <p class="card-title"><%= text.title %></p>
+            <p class="card-text">【<%= text.genre %>】</p>
+          </div>
           </div>
         </div>
       <% end %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,5 @@
+<div class="base-container mw-md">
+  <h2><%= @text.title %></h2>
+  <p><%= markdown(@text.content) %></p>
+  <p id="text-<%= @text.id %>">
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root "texts#index"
-  resources :texts
+  resources :texts, only: [:index, :show]
   devise_for :users
 end


### PR DESCRIPTION
close #16

## 実装内容
★タスク #15 完了後に行って下さい
- 一覧ページから詳細ページに移動できるようにする
- 詳細ページの実装
  - 「内容（content）」は Markdown に対応した表示ができるようにすること
  - スタイルはデフォルトのままでOKです
  - 「読破済み」機能は別タスクとする

## 参考資料

-  Markdown に対応した表示
    - [超便利なMarkdownの基本(やんばるCODE教材)](https://www.yanbaru-code.com/texts/189)
    - [redcarpet公式README](https://github.com/vmg/redcarpet)
    - [Markdown／シンタックスハイライト導入](https://gist.github.com/shu0115/7781776)
    - [【Railsでマークダウン】Gem「redcarpet」を使ってRailsにMarkdownを実装](https://shinmedia20.com/rails-markdown-redcarpet)
    - [Railsでシンタックスハイライトに対応したMarkdownを書く](https://ogihara-ryo.herokuapp.com/blogs/2)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
