### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,4 @@
+class MoviesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,4 +1,5 @@
 class MoviesController < ApplicationController
   def index
+    @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Ruby</a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <%= link_to "Ruby/Railsテキスト教材", texts_path, class: 'dropdown-item' %>
-                <%= link_to "Ruby/Rails動画教材", "#", class: "dropdown-item #{ not_logged_in }"%>
+                <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item #{ not_logged_in }"%>
                 <%= link_to "AWSテキスト教材", "#", class: 'dropdown-item' %>
                 <%= link_to "よくある質問集", "#", class: 'dropdown-item' %>
                 <%= link_to "チャレンジ問題集", "#", class: 'dropdown-item' %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Movies#index</h1>
+<p>Find me in app/views/movies/index.html.erb</p>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,23 @@
-<h1>Movies#index</h1>
-<p>Find me in app/views/movies/index.html.erb</p>
+<div class="contents-title text-center">
+    <h1>Ruby/Rails 動画教材</h1>
+</div>
+<div class="container-fluid">
+  <div class="row">
+    <% @movies.each do |movie| %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card border-dark mb-3">
+          <div class="card-header p-0">
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe width="560" height="315" src=<%= movie.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen"></iframe>
+            </div>
+          </div>
+          <div class="card-body text-dark movie-body">
+            <p class="card-text movie-title">
+                <%= movie.title %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %> 
+  </div>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="contents-title text-center">
-    <h1>Ruby/Rails 動画教材</h1>
+  <h1>Ruby/Rails 動画教材</h1>
 </div>
 <div class="container-fluid">
   <div class="row">
@@ -13,7 +13,7 @@
           </div>
           <div class="card-body text-dark movie-body">
             <p class="card-text movie-title">
-                <%= movie.title %>
+              <%= movie.title %>
             </p>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root "texts#index"
   resources :texts
   devise_for :users
+  resources :movies
 end


### PR DESCRIPTION
close #17

## 実装内容

- Rails動画教材の一覧ページを作成
  - 視聴済み機能・ページネーションは別タスクとする

- Rails動画教材で表示するジャンルは以下のものとすること

```rb
["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
```

- ナビバーの動画教材ページへのリンクが機能するようにする

※Take off Railsなどの広告は削ること

## 参考資料

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
