### PR TITLE
アカウント編集画面実装

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('.title', resource: resource_name.to_s.humanize) %></h1>
+<h1 class="text-center">アカウント編集</h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
@@ -32,6 +32,6 @@
   </div>
 <% end %>
 
-<p><%= t('.unhappy') %>? <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %>.</p>
+<hr class="my-5">
 
-<%= link_to t('.back'), :back %>
+<%= link_to "トップページ", root_path, class: 'btn btn-info btn-block' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -65,7 +65,7 @@
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">マイページ</a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                   <%= link_to "進捗管理", "#", class: 'dropdown-item' %>
-                  <%= link_to "アカウント編集", "#", class: 'dropdown-item' %>
+                  <%= link_to "アカウント編集", edit_user_registration_path, class: 'dropdown-item' %>
                   <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
                 </div>
               </li>


### PR DESCRIPTION
close #46

## 実装内容
- アカウント編集機能実装
  - パスワード機能/パスワード編集機能
- アカウント編集画面のスタイル変更
  - トップページのリンクボタン追加

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
